### PR TITLE
[frmj] base emoji url generation on ID instead of url

### DIFF
--- a/plugins/freemoji/slateTreeProcessor.js
+++ b/plugins/freemoji/slateTreeProcessor.js
@@ -38,7 +38,7 @@ export default (slateTree) => {
 				) {
 					// add to emotes to send
 					extractedEmojis.push(
-						`${emoji.url.split("?")[0]}?size=${getEmoteSize()}`,
+						`https://cdn.discordapp.com/emojis/${emoji.id}?size=${getEmoteSize()}`,
 					);
 					// don't add to the line
 					continue;


### PR DESCRIPTION
Discord seems to have removed the url from the react fiber. Meanwhile we might just hardcode Discord URLs so that this will only break when Discord eventually™ decommissions the discordapp.com domain.

May fix #19, bit of a hack? I have not tested this because I am irresponsible

Edit: I have now tested this by replacing the respective line of code in DevTools. According to responsible® Discord, this should work. 

Edit 2: This should also do a minor performance increase by not needing to split a string. I also forgot to include any file extension, but this seems to work anyway.

ETA: Help I'm trapped in a "worst acronym ever for edit indications" factory©